### PR TITLE
Clarified that Jasmine is a library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+**/lib/**/*.js linguist-vendored
+**/SpecRunner.html linguist-vendored


### PR DESCRIPTION
github-linguist doesn't account for Jasmine as a library so it will classify your repository as a JavaScript repo. This should fix that.